### PR TITLE
ampState, enableAmpBind, enableRemoveIs

### DIFF
--- a/src/ampPage.js
+++ b/src/ampPage.js
@@ -1,4 +1,5 @@
 import ampScripts from './ampScripts';
+import ampState from './ampState';
 
 export default (body, style, options = {}) =>
 `<!doctype html>
@@ -25,6 +26,7 @@ export default (body, style, options = {}) =>
     ${style}
   </head>
   <body>
+  ${ampState(options.ampState)}
   ${body}
   </body>
 </html>

--- a/src/ampState.js
+++ b/src/ampState.js
@@ -1,0 +1,10 @@
+export default function ampState(data) {
+  if (!data) return '';
+  return Object.entries(data).map(([key, value]) => (
+    `<amp-state id="${key}">
+      <script type="application/json">
+      ${JSON.stringify(value)}
+      </script>
+    </amp-state>`
+  )).join('\n');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,19 @@ export const renderReactAmpWithAphrodite = (name, component, ampOptions = {}) =>
       const appendCSS = ampOptions.appendCSS || '';
       const style = `<style amp-custom>\n${prependCSS}${css.content}${appendCSS}\n</style>`;
 
-      return ampPage(html, style, ampOptions);
+      let result = ampPage(html, style, ampOptions);
+
+      if (ampOptions.enableAmpBind) {
+        // transform: amp-bind-attribute-name=   -->   [attribute-name]=
+        result = result.replace(/amp-bind-([\w-]+)=/g, '[$1]=');
+      }
+
+      if (ampOptions.enableRemoveIs) {
+        // remove: is="true"
+        result = result.replace(/is="true"/g, '');
+      }
+
+      return result;
     };
   },
 });

--- a/test/ampState-test.js
+++ b/test/ampState-test.js
@@ -1,0 +1,29 @@
+import { assert } from 'chai';
+import ampState from '../lib/ampState';
+
+describe('ampState', () => {
+  it('returns empty string when first argument is falsy or empty object', () => {
+    assert.isNotOk(ampState(false));
+    assert.isNotOk(ampState(null));
+    assert.isNotOk(ampState(undefined));
+    assert.isNotOk(ampState({}));
+  });
+
+  it('injects state', () => {
+    const STATE = {
+      foo: {
+        one: 'aaa',
+        two: 111,
+      },
+      bar: {
+        three: 'bbb',
+        four: 222,
+      },
+    };
+    const result = ampState(STATE);
+
+    assert.isString(result);
+    assert.ok(result.includes(JSON.stringify(STATE.foo)));
+    assert.ok(result.includes(JSON.stringify(STATE.bar)));
+  });
+});


### PR DESCRIPTION
All of these features are used together when you need to `amp-bind`. However, `enableRemoveIs` may be useful in other cases as well.

Honestly there is probably [a better way to deal with the DOM transforms](http://stackoverflow.com/questions/43296181/custom-react-attributes-with-brackets) in this PR... I haven't figured it out yet though.

https://www.ampproject.org/docs/reference/components/dynamic/amp-bind

@ljharb 
