### PR TITLE
[HYPERNOVA_AMP] add support for google analytics

### DIFF
--- a/src/ampJson.js
+++ b/src/ampJson.js
@@ -1,10 +1,19 @@
-export default function ampJson(data, component) {
+function sanitize(component) {
+  if (!component) {
+    return component;
+  }
+
+  return encodeURIComponent(component);
+}
+
+export default function ampJson(data, component, type) {
   if (!data || !component) return '';
+
   return Object.entries(data).map(([key, value]) => (
-    `<${component} id="${key}">
+    `<${sanitize(component)} id="${sanitize(key)}"${type ? ` type="${sanitize(type)}"` : ''}>
       <script type="application/json">
       ${JSON.stringify(value)}
       </script>
-    </${component}>`
+    </${sanitize(component)}>`
   )).join('\n');
 }

--- a/src/ampPage.js
+++ b/src/ampPage.js
@@ -35,6 +35,7 @@ export default (body, style, options = {}) =>
   <body>
   ${ampJson(options.ampState, 'amp-state')}
   ${ampJson(options.ampAnalytics, 'amp-analytics')}
+  ${ampJson(options.ampGoogleAnalytics, 'amp-analytics', 'googleanalytics')}
   ${body}
   </body>
 </html>

--- a/test/ampJson-test.js
+++ b/test/ampJson-test.js
@@ -26,4 +26,26 @@ describe('ampJson', () => {
     assert.ok(result.includes(JSON.stringify(STATE.foo)));
     assert.ok(result.includes(JSON.stringify(STATE.bar)));
   });
+
+  it('injects attributes', () => {
+    const STATE = {
+      foo: {
+        one: 'aaa',
+        two: 111,
+      },
+      bar: {
+        three: 'bbb',
+        four: 222,
+      },
+    };
+
+    const result = ampJson(STATE, 'amp-analytics', 'googleanalytics');
+    assert.ok(result.includes('type="googleanalytics"'));
+  });
+
+  it('does not inject bad content', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    const result = ampJson({}, 'amp-analytics', maliciousScript);
+    assert.ok(!result.includes(maliciousScript));
+  })
 });


### PR DESCRIPTION
## WHAT? WHY?

This PR adds support for extra attributes for `ampJson`. It will allow for adding google analytics using `amp-analytics`.

Test case:
unit test.

to: @gilbox 