### PR TITLE
[AMP] Add Google Analytics support and sanitize inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "react-dom": "^15.4.2",
     "rimraf": "^2.5.4",
     "sinon": "^1.17.7"
+  },
+  "dependencies": {
+    "sanitize-html": "^1.14.1"
   }
 }

--- a/src/ampJson.js
+++ b/src/ampJson.js
@@ -1,10 +1,13 @@
-export default function ampJson(data, component) {
+import { sanitizeAttrVal, sanitizeElementName, sanitizeJSON } from './sanitize';
+
+export default function ampJson(data, component, type) {
   if (!data || !component) return '';
+
   return Object.entries(data).map(([key, value]) => (
-    `<${component} id="${key}">
+    `<${sanitizeElementName(component)} id="${sanitizeAttrVal(key)}"${type ? ` type="${sanitizeAttrVal(type)}"` : ''}>
       <script type="application/json">
-      ${JSON.stringify(value)}
+      ${sanitizeJSON(value)}
       </script>
-    </${component}>`
+    </${sanitizeElementName(component)}>`
   )).join('\n');
 }

--- a/src/ampPage.js
+++ b/src/ampPage.js
@@ -1,9 +1,10 @@
 import ampScripts from './ampScripts';
 import ampJson from './ampJson';
+import { sanitizeMarkup, sanitizeAttrVal, sanitizeCSS } from './sanitize';
 
 function ampExperimentToken(token) {
   if (!token) return '';
-  return `<meta name="amp-experiment-token" content="${token}">\n`;
+  return `<meta name="amp-experiment-token" content="${sanitizeAttrVal(token)}">\n`;
 }
 
 export default (body, style, options = {}) =>
@@ -15,26 +16,27 @@ export default (body, style, options = {}) =>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     ${ampScripts(options.scripts)
     }${ampExperimentToken(options.ampExperimentToken)
-    }<title>${options.title}</title>
-    <link rel="canonical" href="${options.canonicalUrl}" />
+    }<title>${sanitizeMarkup(options.title)}</title>
+    <link rel="canonical" href="${sanitizeAttrVal(options.canonicalUrl)}" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
         "@context": "http://schema.org",
-        "@type": "${options.schemaType}",
-        "headline": "${options.schemaHeadline}",
-        "datePublished": "${options.schemaDatePublished}",
+        "@type": "${sanitizeMarkup(options.schemaType)}",
+        "headline": "${sanitizeMarkup(options.schemaHeadline)}",
+        "datePublished": "${sanitizeMarkup(options.schemaDatePublished)}",
         "image": [
-          "${options.schemaImage}"
+          "${sanitizeMarkup(options.schemaImage)}"
         ]
       }
     </script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    ${style}
+    ${sanitizeCSS(style)}
   </head>
   <body>
   ${ampJson(options.ampState, 'amp-state')}
   ${ampJson(options.ampAnalytics, 'amp-analytics')}
+  ${ampJson(options.ampGoogleAnalytics, 'amp-analytics', 'googleanalytics')}
   ${body}
   </body>
 </html>

--- a/src/ampScripts.js
+++ b/src/ampScripts.js
@@ -1,6 +1,8 @@
+import { sanitizeAttrVal } from './sanitize';
+
 export default function ampScripts(scripts) {
   if (!scripts) return '';
   return scripts.reduce((acc, { customElement, src }) => (
-    `${acc}<script async custom-element="${customElement}" src="${src}"></script>\n`
+    `${acc}<script async custom-element="${sanitizeAttrVal(customElement)}" src="${sanitizeAttrVal(src)}"></script>\n`
   ), '');
 }

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,0 +1,19 @@
+import sanitizeHtml from 'sanitize-html';
+
+const clean = dirty => sanitizeHtml(dirty, {
+  allowedTags: [],
+  allowedClasses: [],
+});
+
+export const sanitizeElementName = clean;
+export const sanitizeAttrVal = clean;
+export const sanitizeJSON = dirty => JSON.stringify(dirty).replace(/</g, '\\u003c');
+export const sanitizeMarkup = clean;
+
+export const sanitizeCSS = dirty => sanitizeHtml(dirty, {
+  allowedTags: ['style'],
+  allowedAttributes: {
+    style: ['amp-custom'],
+  },
+  allowedClasses: [],
+});

--- a/test/ampJson-test.js
+++ b/test/ampJson-test.js
@@ -26,4 +26,20 @@ describe('ampJson', () => {
     assert.ok(result.includes(JSON.stringify(STATE.foo)));
     assert.ok(result.includes(JSON.stringify(STATE.bar)));
   });
+
+  it('injects attributes', () => {
+    const STATE = {
+      foo: {
+        one: 'aaa',
+        two: 111,
+      },
+      bar: {
+        three: 'bbb',
+        four: 222,
+      },
+    };
+
+    const result = ampJson(STATE, 'amp-analytics', 'googleanalytics');
+    assert.ok(result.includes('type="googleanalytics"'));
+  });
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import AphroditeComponent from './components/AphroditeComponent';
 import { renderReactAmpWithAphrodite } from '../';
 
-describe('aphrodite css rendering', () => {
+describe('index', () => {
   describe('without options', () => {
     let result;
     beforeEach(() => {
@@ -14,7 +14,6 @@ describe('aphrodite css rendering', () => {
 
     it('the markup looks good', () => {
       assert.isString(result);
-
       assert.ok(/html amp/.test(result));
       assert.ok(/style amp-custom/.test(result));
     });

--- a/test/sanitize-test.js
+++ b/test/sanitize-test.js
@@ -1,0 +1,37 @@
+import { assert } from 'chai';
+import {
+  sanitizeElementName,
+  sanitizeAttrVal,
+  sanitizeJSON,
+  sanitizeCSS,
+  sanitizeMarkup,
+} from '../lib/sanitize';
+
+describe('sanitize prevents XSS', () => {
+  it('sanitizeElementName', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    assert.notOk(sanitizeElementName(maliciousScript).includes(maliciousScript));
+  });
+
+  it('sanitizeAttrVal', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    assert.notOk(sanitizeAttrVal(maliciousScript).includes(maliciousScript));
+  });
+
+  it('sanitizeJSON', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    assert.notOk(sanitizeJSON(maliciousScript).includes(maliciousScript));
+  });
+
+  it('sanitizeCSS', () => {
+    const maliciousScript = '<style amp-custom></style><script>malicious script</script>';
+    const result = sanitizeCSS(maliciousScript);
+    assert.notOk(result.includes('<script>malicious script</script>'));
+    assert.ok(result.includes('<style amp-custom>'));
+  });
+
+  it('sanitizeMarkup', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    assert.notOk(sanitizeMarkup(maliciousScript).includes(maliciousScript));
+  });
+});


### PR DESCRIPTION
Took over Jeremey's PR to add sanitization everywhere, except for `body` because it is react output.

@ljharb 