### PR TITLE
Updates hypernova peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/airbnb/hypernova-amp",
   "peerDependencies": {
     "aphrodite": "^0.5.0 || ^1.1.0",
-    "hypernova": "^1.0.0",
+    "hypernova": "^2.0.0",
     "react": "0.14.x || >= 15.x",
     "react-dom": "0.14.x || >= 15.x"
   },


### PR DESCRIPTION
This is ok to bump up to latest since we're not using any of the breaking hypernova features.

@gilbox @ljharb 