### PR TITLE
[createAmpRender] refactor render functionality into createAmpRender

### DIFF
--- a/src/createAmpRender.js
+++ b/src/createAmpRender.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { StyleSheetServer } from 'aphrodite/no-important';
+import ampPage from './ampPage';
+
+// eslint-disable-next-line import/prefer-default-export
+export default function createAmpRender(component, ampOptions = {}) {
+  return (props) => {
+    const { html, css } = StyleSheetServer.renderStatic(() => (
+      ReactDOMServer.renderToString(React.createElement(component, props))
+    ));
+
+    const prependCSS = ampOptions.prependCSS || '';
+    const appendCSS = ampOptions.appendCSS || '';
+    const style = `<style amp-custom>\n${prependCSS}${css.content}${appendCSS}\n</style>`;
+
+    let result = ampPage(html, style, ampOptions);
+
+    if (ampOptions.enableAmpBind) {
+      // transform: amp-bind-attribute-name=   -->   [attribute-name]=
+      result = result.replace(/amp-bind-([\w-]+)=/g, '[$1]=');
+    }
+
+    if (ampOptions.enableRemoveIs) {
+      // remove: is="true"
+      result = result.replace(/is="true"/g, '');
+    }
+
+    return result;
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,12 @@
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import hypernova from 'hypernova';
-import { StyleSheetServer } from 'aphrodite/no-important';
-import ampPage from './ampPage';
+import createAmpRender from './createAmpRender';
 
 // eslint-disable-next-line import/prefer-default-export
 export const renderReactAmpWithAphrodite = (name, component, ampOptions = {}) => hypernova({
   server() {
-    return (props) => {
-      const { html, css } = StyleSheetServer.renderStatic(() => (
-        ReactDOMServer.renderToString(React.createElement(component, props))
-      ));
-
-      const prependCSS = ampOptions.prependCSS || '';
-      const appendCSS = ampOptions.appendCSS || '';
-      const style = `<style amp-custom>\n${prependCSS}${css.content}${appendCSS}\n</style>`;
-
-      let result = ampPage(html, style, ampOptions);
-
-      if (ampOptions.enableAmpBind) {
-        // transform: amp-bind-attribute-name=   -->   [attribute-name]=
-        result = result.replace(/amp-bind-([\w-]+)=/g, '[$1]=');
-      }
-
-      if (ampOptions.enableRemoveIs) {
-        // remove: is="true"
-        result = result.replace(/is="true"/g, '');
-      }
-
-      return result;
-    };
+    // TODO(gil): The `name` arg is ignored. It historically exists to
+    // match the arguments of renderReactWithAphrodite from the hypernova-aphrodite
+    // package but should probably be removed
+    return createAmpRender(component, ampOptions);
   },
 });


### PR DESCRIPTION
I'd like to be able to render an AMP page without getting hypernova involved. This is useful for validation and for integration with storybook.

It's used this way:

```
import createAmpRender from 'hypernova-amp/lib/createAmpRender';
```

Adds an import... so minor change?

@goatslacker 
@ljharb 