### PR TITLE
[jsonSchema] Support unlimited JSON Schema object

### DIFF
--- a/src/ampPage.js
+++ b/src/ampPage.js
@@ -1,6 +1,6 @@
 import ampScripts from './ampScripts';
 import ampJson from './ampJson';
-import { sanitizeMarkup, sanitizeAttrVal, sanitizeCSS } from './sanitize';
+import { sanitizeMarkup, sanitizeAttrVal, sanitizeCSS, sanitizeJSON } from './sanitize';
 
 function ampExperimentToken(token) {
   if (!token) return '';
@@ -19,17 +19,9 @@ export default (body, style, options = {}) =>
     }<title>${sanitizeMarkup(options.title)}</title>
     <link rel="canonical" href="${sanitizeAttrVal(options.canonicalUrl)}" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <script type="application/ld+json">
-      {
-        "@context": "http://schema.org",
-        "@type": "${sanitizeMarkup(options.schemaType)}",
-        "headline": "${sanitizeMarkup(options.schemaHeadline)}",
-        "datePublished": "${sanitizeMarkup(options.schemaDatePublished)}",
-        "image": [
-          "${sanitizeMarkup(options.schemaImage)}"
-        ]
-      }
-    </script>
+    ${options.jsonSchema ?
+      `<script type="application/ld+json">${sanitizeJSON(options.jsonSchema)}</script>` :
+      '<!-- WARNING: Missing JSON Schema -->'}
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     ${sanitizeCSS(style)}
   </head>

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -8,7 +8,10 @@ const clean = dirty => sanitizeHtml(dirty, {
 export const sanitizeElementName = clean;
 export const sanitizeAttrVal = clean;
 export const sanitizeAttr = clean;
-export const sanitizeJSON = dirty => JSON.stringify(dirty).replace(/</g, '\\u003c');
+export const sanitizeJSON = (dirty) => {
+  const result = JSON.stringify(dirty);
+  return result && result.replace(/</g, '\\u003c');
+};
 export const sanitizeMarkup = clean;
 
 export const sanitizeCSS = dirty => sanitizeHtml(dirty, {

--- a/test/ampPage-test.js
+++ b/test/ampPage-test.js
@@ -2,27 +2,43 @@ import { assert } from 'chai';
 import ampPage from '../lib/ampPage';
 
 describe('ampPage', () => {
-  it('injects body, style, and options', () => {
-    const BODY = 'XXXBODYXXX';
-    const STYLE = 'XXXSTYLEXXX';
-    const OPTIONS = {
+  let body;
+  let style;
+  let options;
+
+  beforeEach(() => {
+    body = 'XXXBODYXXX';
+    style = 'XXXSTYLEXXX';
+    options = {
       title: 'LSCLIZJOIWE',
       canonicalUrl: 'OINALKSDMC',
-      schemaType: 'AIOJVKJZVDV',
-      schemaHeadline: 'ASLDIFJ2OIEFAD',
-      schemaDatePublished: 'AOCIMOAISDJF',
       ampExperimentToken: 'kll2j3lkj23lj',
+      jsonSchema: {
+        '@context': 'http://schema.org',
+        '@type': 'AIOJVKJZVDV',
+        headline: 'ASLDIFJ2OIEFAD',
+        datePublished: 'AOCIMOAISDJF',
+      },
     };
-    const result = ampPage(BODY, STYLE, OPTIONS);
+  });
+
+  it('injects body, style, and options', () => {
+    const result = ampPage(body, style, options);
 
     assert.isString(result);
-    assert.ok(result.includes(BODY));
-    assert.ok(result.includes(STYLE));
-    assert.ok(result.includes(OPTIONS.title));
-    assert.ok(result.includes(OPTIONS.canonicalUrl));
-    assert.ok(result.includes(OPTIONS.schemaType));
-    assert.ok(result.includes(OPTIONS.schemaHeadline));
-    assert.ok(result.includes(OPTIONS.schemaDatePublished));
-    assert.ok(result.includes(OPTIONS.ampExperimentToken));
+    assert.include(result, body, 'result includes body');
+    assert.include(result, style, 'result includes style');
+    assert.include(result, options.title, 'result includes title');
+    assert.include(result, options.canonicalUrl, 'result includes canonicalUrl');
+    assert.include(result, options.jsonSchema['@context'], 'result includes @context');
+    assert.include(result, options.jsonSchema['@type'], 'result includes @type');
+    assert.include(result, options.jsonSchema.headline, 'result includes headline');
+    assert.include(result, options.jsonSchema.datePublished, 'result includes datePublished');
+    assert.include(result, options.ampExperimentToken, 'result includes ampExperimentToken');
+  });
+
+  it('warns about missing JSON Schema', () => {
+    const result = ampPage(body, style, { ...options, jsonSchema: undefined });
+    assert.include(result, '<!-- WARNING: Missing JSON Schema -->');
   });
 });

--- a/test/sanitize-test.js
+++ b/test/sanitize-test.js
@@ -24,9 +24,27 @@ describe('sanitize prevents XSS', () => {
     assert.notOk(sanitizeAttrVal(maliciousScript).includes(maliciousScript));
   });
 
-  it('sanitizeJSON', () => {
-    const maliciousScript = '<script>malicious script</script>';
-    assert.notOk(sanitizeJSON(maliciousScript).includes(maliciousScript));
+  describe('sanitizeJSON', () => {
+    it('santizes', () => {
+      const maliciousScript = '<script>malicious script</script>';
+      assert.notOk(sanitizeJSON(maliciousScript).includes(maliciousScript));
+    });
+
+    it('handles undefined', () => {
+      assert.equal(sanitizeJSON(undefined), undefined);
+    });
+
+    it('handles null', () => {
+      assert.equal(sanitizeJSON(null), 'null');
+    });
+
+    it('handles false', () => {
+      assert.equal(sanitizeJSON(false), 'false');
+    });
+
+    it('handles 0', () => {
+      assert.equal(sanitizeJSON(0), '0');
+    });
   });
 
   it('sanitizeCSS', () => {


### PR DESCRIPTION
Prior to this change, JSON schema was limited to supporting only specific options. Now instead of schemaX options, we simply pass in a full schema object to the jsonSchema option. Note that it will now be necessary to add the @context and @type keys to the schema object. This is a breaking change.
Also improve the sanitizeJSON function to support value of undefined.