### PR TITLE
Add custom-template option for ampScripts

### DIFF
--- a/src/ampJson.js
+++ b/src/ampJson.js
@@ -1,13 +1,14 @@
-import { sanitizeAttrVal, sanitizeElementName, sanitizeJSON } from './sanitize';
+import createElement from './createElement';
 
 export default function ampJson(data, component, type) {
   if (!data || !component) return '';
 
-  return Object.entries(data).map(([key, value]) => (
-    `<${sanitizeElementName(component)} id="${sanitizeAttrVal(key)}"${type ? ` type="${sanitizeAttrVal(type)}"` : ''}>
-      <script type="application/json">
-      ${sanitizeJSON(value)}
-      </script>
-    </${sanitizeElementName(component)}>`
+  return Object.entries(data).map(([id, value]) => createElement(
+    component,
+    {
+      id,
+      type,
+    },
+    createElement('script', { type: 'application/json' }, value),
   )).join('\n');
 }

--- a/src/ampScripts.js
+++ b/src/ampScripts.js
@@ -1,8 +1,12 @@
-import { sanitizeAttrVal } from './sanitize';
+import createElement from './createElement';
 
 export default function ampScripts(scripts) {
   if (!scripts) return '';
-  return scripts.reduce((acc, { customElement, src }) => (
-    `${acc}<script async custom-element="${sanitizeAttrVal(customElement)}" src="${sanitizeAttrVal(src)}"></script>\n`
-  ), '');
+  const result = scripts.map(({ customElement, customTemplate, src }) => createElement('script', {
+    async: true,
+    'custom-element': customElement,
+    'custom-template': customTemplate,
+    src,
+  })).join('\n');
+  return result ? `${result}\n` : '';
 }

--- a/src/createElement.js
+++ b/src/createElement.js
@@ -1,0 +1,15 @@
+import { sanitizeAttr, sanitizeAttrVal, sanitizeElementName, sanitizeJSON } from './sanitize';
+
+export default function createElement(element, attributes, children = '') {
+  const sanitizedElement = sanitizeElementName(element);
+  const attributesString = attributes ? ` ${Object.entries(attributes).map(([attr, val]) => {
+    if (val == null) return '';
+    if (val === true) return sanitizeAttr(attr);
+    if (val === false) { return ''; }
+    return `${sanitizeAttr(attr)}="${sanitizeAttrVal(val)}"`;
+  }).filter(Boolean).join(' ')}` : '';
+
+  return `<${sanitizedElement}${attributesString}>${
+    typeof children === 'string' ? children : sanitizeJSON(children)
+  }</${sanitizedElement}>`;
+}

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -7,6 +7,7 @@ const clean = dirty => sanitizeHtml(dirty, {
 
 export const sanitizeElementName = clean;
 export const sanitizeAttrVal = clean;
+export const sanitizeAttr = clean;
 export const sanitizeJSON = dirty => JSON.stringify(dirty).replace(/</g, '\\u003c');
 export const sanitizeMarkup = clean;
 

--- a/test/ampScripts-test.js
+++ b/test/ampScripts-test.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import ampScripts from '../lib/ampScripts';
 
 describe('ampScripts', () => {
-  it('returns empty string when first argument is falsy', () => {
+  it('returns empty string when first argument is falsy or empty array', () => {
     assert.isNotOk(ampScripts(false));
     assert.isNotOk(ampScripts(null));
     assert.isNotOk(ampScripts(undefined));
@@ -23,9 +23,19 @@ describe('ampScripts', () => {
     const result = ampScripts(SCRIPTS);
 
     assert.isString(result);
-    assert.ok(result.includes(SCRIPTS[0].customElement));
-    assert.ok(result.includes(SCRIPTS[1].customElement));
-    assert.ok(result.includes(SCRIPTS[0].src));
-    assert.ok(result.includes(SCRIPTS[1].src));
+    assert.include(result, SCRIPTS[0].customElement);
+    assert.include(result, SCRIPTS[1].customElement);
+    assert.include(result, SCRIPTS[0].src);
+    assert.include(result, SCRIPTS[1].src);
+  });
+
+  it('supports customTemplate', () => {
+    assert.equal(
+      ampScripts([{
+        customTemplate: 'my-template',
+        src: 'my.src',
+      }]),
+      '<script async custom-template="my-template" src="my.src"></script>\n',
+    );
   });
 });

--- a/test/createElement-test.js
+++ b/test/createElement-test.js
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+import createElement from '../lib/createElement';
+
+describe('createElement', () => {
+  it('creates element with no attributes, no children', () => {
+    assert.equal(
+      createElement('foo'),
+      '<foo></foo>',
+    );
+  });
+
+  it('creates element with attributes, no children', () => {
+    assert.equal(
+      createElement('foo', { a: 'one', b: 'two' }),
+      '<foo a="one" b="two"></foo>',
+    );
+  });
+
+  it('creates element with children, no attributes', () => {
+    assert.equal(
+      createElement('foo', null, 'bar'),
+      '<foo>bar</foo>',
+    );
+    assert.equal(
+      createElement('foo', undefined, 'bar'),
+      '<foo>bar</foo>',
+    );
+  });
+
+  it('creates element with bare attribute when value is true', () => {
+    assert.equal(
+      createElement('foo', { xxx: true, a: true, b: 'bar' }, 'baz'),
+      '<foo xxx a b="bar">baz</foo>',
+    );
+  });
+
+  it('removes null and undefined attributes', () => {
+    assert.equal(
+      createElement('foo', { a: 'bar', b: null, c: undefined, d: 'baz' }),
+      '<foo a="bar" d="baz"></foo>',
+    );
+  });
+
+  it('removes false attributes', () => {
+    assert.equal(
+      createElement('foo', { a: 'bar', b: false, c: false, d: 'baz' }),
+      '<foo a="bar" d="baz"></foo>',
+    );
+  });
+});

--- a/test/sanitize-test.js
+++ b/test/sanitize-test.js
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import {
   sanitizeElementName,
+  sanitizeAttr,
   sanitizeAttrVal,
   sanitizeJSON,
   sanitizeCSS,
@@ -11,6 +12,11 @@ describe('sanitize prevents XSS', () => {
   it('sanitizeElementName', () => {
     const maliciousScript = '<script>malicious script</script>';
     assert.notOk(sanitizeElementName(maliciousScript).includes(maliciousScript));
+  });
+
+  it('sanitizeAttr', () => {
+    const maliciousScript = '<script>malicious script</script>';
+    assert.notOk(sanitizeAttr(maliciousScript).includes(maliciousScript));
   });
 
   it('sanitizeAttrVal', () => {


### PR DESCRIPTION
Add createElement function for creating elements with boolean and optional attributes
Support HTML templates https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md
see also https://www.ampproject.org/docs/reference/components/amp-list

this is a non-breaking change