### PR TITLE
[amp] Add google analytics

### DIFF
--- a/src/ampJson.js
+++ b/src/ampJson.js
@@ -1,4 +1,4 @@
-import createElement from './createElement';
+import { createElement } from './createElement';
 
 export default function ampJson(data, component, type) {
   if (!data || !component) return '';

--- a/src/ampMetas.js
+++ b/src/ampMetas.js
@@ -1,0 +1,9 @@
+import { createElementNoClosingTag } from './createElement';
+
+export default function ampMetas(metas) {
+  if (!metas) return '';
+  const result = metas.map(
+    meta => createElementNoClosingTag('meta', meta),
+  ).join('\n');
+  return result ? `${result}\n` : '';
+}

--- a/src/ampPage.js
+++ b/src/ampPage.js
@@ -1,5 +1,6 @@
 import ampScripts from './ampScripts';
 import ampJson from './ampJson';
+import ampMetas from './ampMetas';
 import { sanitizeMarkup, sanitizeAttrVal, sanitizeCSS, sanitizeJSON } from './sanitize';
 
 function ampExperimentToken(token) {
@@ -12,11 +13,12 @@ export default (body, style, options = {}) =>
 <html amp lang="en">
   <head>
     <meta charset="utf-8">
+    ${ampMetas(options.metas)}
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-    ${ampScripts(options.scripts)
-    }${ampExperimentToken(options.ampExperimentToken)
-    }<title>${sanitizeMarkup(options.title)}</title>
+    ${ampScripts(options.scripts)}
+    ${ampExperimentToken(options.ampExperimentToken)}
+    <title>${sanitizeMarkup(options.title)}</title>
     <link rel="canonical" href="${sanitizeAttrVal(options.canonicalUrl)}" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     ${options.jsonSchema ?

--- a/src/ampScripts.js
+++ b/src/ampScripts.js
@@ -1,4 +1,4 @@
-import createElement from './createElement';
+import { createElement } from './createElement';
 
 export default function ampScripts(scripts) {
   if (!scripts) return '';

--- a/src/createElement.js
+++ b/src/createElement.js
@@ -1,15 +1,26 @@
 import { sanitizeAttr, sanitizeAttrVal, sanitizeElementName, sanitizeJSON } from './sanitize';
 
-export default function createElement(element, attributes, children = '') {
-  const sanitizedElement = sanitizeElementName(element);
-  const attributesString = attributes ? ` ${Object.entries(attributes).map(([attr, val]) => {
+function generateAttributesString(attributes) {
+  return attributes ? ` ${Object.entries(attributes).map(([attr, val]) => {
     if (val == null) return '';
     if (val === true) return sanitizeAttr(attr);
     if (val === false) { return ''; }
     return `${sanitizeAttr(attr)}="${sanitizeAttrVal(val)}"`;
   }).filter(Boolean).join(' ')}` : '';
+}
+
+export function createElement(element, attributes, children = '') {
+  const sanitizedElement = sanitizeElementName(element);
+  const attributesString = generateAttributesString(attributes);
 
   return `<${sanitizedElement}${attributesString}>${
     typeof children === 'string' ? children : sanitizeJSON(children)
   }</${sanitizedElement}>`;
+}
+
+export function createElementNoClosingTag(element, attributes) {
+  const sanitizedElement = sanitizeElementName(element);
+  const attributesString = generateAttributesString(attributes);
+
+  return `<${sanitizedElement}${attributesString}>`;
 }

--- a/test/ampMetas-test.js
+++ b/test/ampMetas-test.js
@@ -1,0 +1,29 @@
+import { assert } from 'chai';
+import ampMetas from '../lib/ampMetas';
+
+describe('ampMetas', () => {
+  it('returns empty string when first argument is falsy or empty array', () => {
+    assert.isNotOk(ampMetas(false));
+    assert.isNotOk(ampMetas(null));
+    assert.isNotOk(ampMetas(undefined));
+    assert.isNotOk(ampMetas([]));
+  });
+
+  it('injects metas', () => {
+    const METAS = [
+      {
+        name: 'foo',
+        content: 'bar',
+      },
+      {
+        name: 'bar',
+        content: 'foo',
+      },
+    ];
+    const result = ampMetas(METAS);
+
+    assert.isString(result);
+    assert.include(result, '<meta name="foo" content="bar">');
+    assert.include(result, '<meta name="bar" content="foo">');
+  });
+});

--- a/test/createElement-test.js
+++ b/test/createElement-test.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import createElement from '../lib/createElement';
+import { createElement, createElementNoClosingTag } from '../lib/createElement';
 
 describe('createElement', () => {
   it('creates element with no attributes, no children', () => {
@@ -45,6 +45,15 @@ describe('createElement', () => {
     assert.equal(
       createElement('foo', { a: 'bar', b: false, c: false, d: 'baz' }),
       '<foo a="bar" d="baz"></foo>',
+    );
+  });
+});
+
+describe('createElementNoClosingTag', () => {
+  it('creates element with attributes', () => {
+    assert.equal(
+      createElementNoClosingTag('meta', { name: 'foo', content: 'bar' }),
+      '<meta name="foo" content="bar">',
     );
   });
 });


### PR DESCRIPTION
Per https://support.google.com/analytics/answer/7486764?hl=en, adding this tag for Non-AMP -> Amp tracking.

Reviewers: @gilbox @ljharb 